### PR TITLE
Conditionally run CNG tests only on supported platforms.

### DIFF
--- a/test/Microsoft.AspNet.Security.DataProtection.Test/Cng/CbcAuthenticatedEncryptorTests.cs
+++ b/test/Microsoft.AspNet.Security.DataProtection.Test/Cng/CbcAuthenticatedEncryptorTests.cs
@@ -6,13 +6,15 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.AspNet.Security.DataProtection.Cng;
+using Microsoft.AspNet.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNet.Security.DataProtection.Test.Cng
 {
     public class CbcAuthenticatedEncryptorTests
     {
-        [Fact]
+        [ConditionalFact]
+        [ConditionalRunTestOnlyIfBcryptAvailable]
         public void Encrypt_Decrypt_RoundTrips()
         {
             // Arrange
@@ -32,7 +34,8 @@ namespace Microsoft.AspNet.Security.DataProtection.Test.Cng
             Assert.Equal(plaintext, decipheredtext);
         }
 
-        [Fact]
+        [ConditionalFact]
+        [ConditionalRunTestOnlyIfBcryptAvailable]
         public void Encrypt_Decrypt_Tampering_Fails()
         {
             // Arrange
@@ -78,7 +81,8 @@ namespace Microsoft.AspNet.Security.DataProtection.Test.Cng
             });
         }
 
-        [Fact]
+        [ConditionalFact]
+        [ConditionalRunTestOnlyIfBcryptAvailable]
         public void Encrypt_KnownKey()
         {
             // Arrange

--- a/test/Microsoft.AspNet.Security.DataProtection.Test/Cng/CngAuthenticatedEncryptorBaseTests.cs
+++ b/test/Microsoft.AspNet.Security.DataProtection.Test/Cng/CngAuthenticatedEncryptorBaseTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.AspNet.Security.DataProtection.Cng;
+using Microsoft.AspNet.Testing.xunit;
 using Moq;
 using Xunit;
 
@@ -10,7 +11,8 @@ namespace Microsoft.AspNet.Security.DataProtection.Test.Cng
 {
     public unsafe class CngAuthenticatedEncryptorBaseTests
     {
-        [Fact]
+        [ConditionalFact]
+        [ConditionalRunTestOnlyIfBcryptAvailable]
         public void Decrypt_ForwardsArraySegment()
         {
             // Arrange
@@ -35,7 +37,8 @@ namespace Microsoft.AspNet.Security.DataProtection.Test.Cng
             Assert.Equal(new byte[] { 0x20, 0x21, 0x22 }, retVal);
         }
 
-        [Fact]
+        [ConditionalFact]
+        [ConditionalRunTestOnlyIfBcryptAvailable]
         public void Decrypt_HandlesEmptyAADPointerFixup()
         {
             // Arrange
@@ -60,7 +63,8 @@ namespace Microsoft.AspNet.Security.DataProtection.Test.Cng
             Assert.Equal(new byte[] { 0x20, 0x21, 0x22 }, retVal);
         }
 
-        [Fact]
+        [ConditionalFact]
+        [ConditionalRunTestOnlyIfBcryptAvailable]
         public void Decrypt_HandlesEmptyCiphertextPointerFixup()
         {
             // Arrange

--- a/test/Microsoft.AspNet.Security.DataProtection.Test/Cng/GcmAuthenticatedEncryptorTests.cs
+++ b/test/Microsoft.AspNet.Security.DataProtection.Test/Cng/GcmAuthenticatedEncryptorTests.cs
@@ -6,13 +6,15 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.AspNet.Security.DataProtection.Cng;
+using Microsoft.AspNet.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNet.Security.DataProtection.Test.Cng
 {
     public class GcmAuthenticatedEncryptorTests
     {
-        [Fact]
+        [ConditionalFact]
+        [ConditionalRunTestOnlyIfBcryptAvailable]
         public void Encrypt_Decrypt_RoundTrips()
         {
             // Arrange
@@ -29,7 +31,8 @@ namespace Microsoft.AspNet.Security.DataProtection.Test.Cng
             Assert.Equal(plaintext, decipheredtext);
         }
 
-        [Fact]
+        [ConditionalFact]
+        [ConditionalRunTestOnlyIfBcryptAvailable]
         public void Encrypt_Decrypt_Tampering_Fails()
         {
             // Arrange
@@ -72,7 +75,8 @@ namespace Microsoft.AspNet.Security.DataProtection.Test.Cng
             });
         }
 
-        [Fact]
+        [ConditionalFact]
+        [ConditionalRunTestOnlyIfBcryptAvailable]
         public void Encrypt_KnownKey()
         {
             // Arrange

--- a/test/Microsoft.AspNet.Security.DataProtection.Test/ConditionalRunTestOnlyIfBcryptAvailableAttribute.cs
+++ b/test/Microsoft.AspNet.Security.DataProtection.Test/ConditionalRunTestOnlyIfBcryptAvailableAttribute.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using Microsoft.AspNet.Security.DataProtection.SafeHandles;
+using Microsoft.AspNet.Testing.xunit;
+
+namespace Microsoft.AspNet.Security.DataProtection.Test
+{
+    public class ConditionalRunTestOnlyIfBcryptAvailableAttribute : Attribute, ITestCondition
+    {
+        private static readonly SafeLibraryHandle _bcryptLibHandle = GetBcryptLibHandle();
+
+        private readonly string _requiredExportFunction;
+
+        public ConditionalRunTestOnlyIfBcryptAvailableAttribute(string requiredExportFunction = null)
+        {
+            _requiredExportFunction = requiredExportFunction;
+        }
+
+        public bool IsMet
+        {
+            get
+            {
+                if (_bcryptLibHandle == null)
+                {
+                    return false; // no bcrypt.dll available
+                }
+
+                return (_requiredExportFunction == null || _bcryptLibHandle.DoesProcExist(_requiredExportFunction));
+            }
+        }
+
+        public string SkipReason
+        {
+            get
+            {
+                return (_bcryptLibHandle != null)
+                    ? String.Format(CultureInfo.InvariantCulture, "Export {0} not found in bcrypt.dll", _requiredExportFunction)
+                    : "bcrypt.dll not found on this platform.";
+            }
+        }
+
+        private static SafeLibraryHandle GetBcryptLibHandle()
+        {
+            try
+            {
+                return SafeLibraryHandle.Open("bcrypt.dll");
+            }
+            catch
+            {
+                // If we're not on an OS with BCRYPT.DLL, just bail.
+                return null;
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Security.DataProtection.Test/PBKDF2/Pbkdf2Tests.cs
+++ b/test/Microsoft.AspNet.Security.DataProtection.Test/PBKDF2/Pbkdf2Tests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Text;
 using Microsoft.AspNet.Security.DataProtection.PBKDF2;
+using Microsoft.AspNet.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNet.Security.DataProtection.Test.PBKDF2
@@ -23,7 +24,7 @@ namespace Microsoft.AspNet.Security.DataProtection.Test.PBKDF2
         [InlineData("my-password", KeyDerivationPrf.Sha512, 5, 512 / 8 - 1, "ZTallQJrFn0279xIzaiA1XqatVTGei+ZjKngA7bIMtKMDUw6YJeGUQpFG8iGTgN+ri3LNDktNbzwfcSyZmm9")]
         [InlineData("my-password", KeyDerivationPrf.Sha512, 5, 512 / 8 + 0, "ZTallQJrFn0279xIzaiA1XqatVTGei+ZjKngA7bIMtKMDUw6YJeGUQpFG8iGTgN+ri3LNDktNbzwfcSyZmm90Q==")]
         [InlineData("my-password", KeyDerivationPrf.Sha512, 5, 512 / 8 + 1, "ZTallQJrFn0279xIzaiA1XqatVTGei+ZjKngA7bIMtKMDUw6YJeGUQpFG8iGTgN+ri3LNDktNbzwfcSyZmm90Wk=")]
-        public void RunTest_Normal(string password, KeyDerivationPrf prf, int iterationCount, int numBytesRequested, string expectedValueAsBase64)
+        public void RunTest_Normal_Managed(string password, KeyDerivationPrf prf, int iterationCount, int numBytesRequested, string expectedValueAsBase64)
         {
             // Arrange
             byte[] salt = new byte[256];
@@ -32,14 +33,86 @@ namespace Microsoft.AspNet.Security.DataProtection.Test.PBKDF2
                 salt[i] = (byte)i;
             }
 
-            // Act & assert - fully managed, Win7, and Win8
+            // Act & assert
             TestProvider<ManagedPbkdf2Provider>(password, salt, prf, iterationCount, numBytesRequested, expectedValueAsBase64);
+        }
+
+        // The 'numBytesRequested' parameters below are chosen to exercise code paths where
+        // this value straddles the digest length of the PRF. We only use 5 iterations so
+        // that our unit tests are fast.
+        [ConditionalTheory]
+        [ConditionalRunTestOnlyIfBcryptAvailable("BCryptDeriveKeyPBKDF2")]
+        [InlineData("my-password", KeyDerivationPrf.Sha1, 5, 160 / 8 - 1, "efmxNcKD/U1urTEDGvsThlPnHA==")]
+        [InlineData("my-password", KeyDerivationPrf.Sha1, 5, 160 / 8 + 0, "efmxNcKD/U1urTEDGvsThlPnHDI=")]
+        [InlineData("my-password", KeyDerivationPrf.Sha1, 5, 160 / 8 + 1, "efmxNcKD/U1urTEDGvsThlPnHDLk")]
+        [InlineData("my-password", KeyDerivationPrf.Sha256, 5, 256 / 8 - 1, "JRNz8bPKS02EG1vf7eWjA64IeeI+TI8gBEwb1oVvRA==")]
+        [InlineData("my-password", KeyDerivationPrf.Sha256, 5, 256 / 8 + 0, "JRNz8bPKS02EG1vf7eWjA64IeeI+TI8gBEwb1oVvRLo=")]
+        [InlineData("my-password", KeyDerivationPrf.Sha256, 5, 256 / 8 + 1, "JRNz8bPKS02EG1vf7eWjA64IeeI+TI8gBEwb1oVvRLpk")]
+        [InlineData("my-password", KeyDerivationPrf.Sha512, 5, 512 / 8 - 1, "ZTallQJrFn0279xIzaiA1XqatVTGei+ZjKngA7bIMtKMDUw6YJeGUQpFG8iGTgN+ri3LNDktNbzwfcSyZmm9")]
+        [InlineData("my-password", KeyDerivationPrf.Sha512, 5, 512 / 8 + 0, "ZTallQJrFn0279xIzaiA1XqatVTGei+ZjKngA7bIMtKMDUw6YJeGUQpFG8iGTgN+ri3LNDktNbzwfcSyZmm90Q==")]
+        [InlineData("my-password", KeyDerivationPrf.Sha512, 5, 512 / 8 + 1, "ZTallQJrFn0279xIzaiA1XqatVTGei+ZjKngA7bIMtKMDUw6YJeGUQpFG8iGTgN+ri3LNDktNbzwfcSyZmm90Wk=")]
+        public void RunTest_Normal_Win7(string password, KeyDerivationPrf prf, int iterationCount, int numBytesRequested, string expectedValueAsBase64)
+        {
+            // Arrange
+            byte[] salt = new byte[256];
+            for (int i = 0; i < salt.Length; i++)
+            {
+                salt[i] = (byte)i;
+            }
+
+            // Act & assert
             TestProvider<Win7Pbkdf2Provider>(password, salt, prf, iterationCount, numBytesRequested, expectedValueAsBase64);
+        }
+
+        // The 'numBytesRequested' parameters below are chosen to exercise code paths where
+        // this value straddles the digest length of the PRF. We only use 5 iterations so
+        // that our unit tests are fast.
+        [ConditionalTheory]
+        [ConditionalRunTestOnlyIfBcryptAvailable("BCryptKeyDerivation")]
+        [InlineData("my-password", KeyDerivationPrf.Sha1, 5, 160 / 8 - 1, "efmxNcKD/U1urTEDGvsThlPnHA==")]
+        [InlineData("my-password", KeyDerivationPrf.Sha1, 5, 160 / 8 + 0, "efmxNcKD/U1urTEDGvsThlPnHDI=")]
+        [InlineData("my-password", KeyDerivationPrf.Sha1, 5, 160 / 8 + 1, "efmxNcKD/U1urTEDGvsThlPnHDLk")]
+        [InlineData("my-password", KeyDerivationPrf.Sha256, 5, 256 / 8 - 1, "JRNz8bPKS02EG1vf7eWjA64IeeI+TI8gBEwb1oVvRA==")]
+        [InlineData("my-password", KeyDerivationPrf.Sha256, 5, 256 / 8 + 0, "JRNz8bPKS02EG1vf7eWjA64IeeI+TI8gBEwb1oVvRLo=")]
+        [InlineData("my-password", KeyDerivationPrf.Sha256, 5, 256 / 8 + 1, "JRNz8bPKS02EG1vf7eWjA64IeeI+TI8gBEwb1oVvRLpk")]
+        [InlineData("my-password", KeyDerivationPrf.Sha512, 5, 512 / 8 - 1, "ZTallQJrFn0279xIzaiA1XqatVTGei+ZjKngA7bIMtKMDUw6YJeGUQpFG8iGTgN+ri3LNDktNbzwfcSyZmm9")]
+        [InlineData("my-password", KeyDerivationPrf.Sha512, 5, 512 / 8 + 0, "ZTallQJrFn0279xIzaiA1XqatVTGei+ZjKngA7bIMtKMDUw6YJeGUQpFG8iGTgN+ri3LNDktNbzwfcSyZmm90Q==")]
+        [InlineData("my-password", KeyDerivationPrf.Sha512, 5, 512 / 8 + 1, "ZTallQJrFn0279xIzaiA1XqatVTGei+ZjKngA7bIMtKMDUw6YJeGUQpFG8iGTgN+ri3LNDktNbzwfcSyZmm90Wk=")]
+        public void RunTest_Normal_Win8(string password, KeyDerivationPrf prf, int iterationCount, int numBytesRequested, string expectedValueAsBase64)
+        {
+            // Arrange
+            byte[] salt = new byte[256];
+            for (int i = 0; i < salt.Length; i++)
+            {
+                salt[i] = (byte)i;
+            }
+
+            // Act & assert
             TestProvider<Win8Pbkdf2Provider>(password, salt, prf, iterationCount, numBytesRequested, expectedValueAsBase64);
         }
 
         [Fact]
-        public void RunTest_WithLongPassword()
+        public void RunTest_WithLongPassword_Managed()
+        {
+            RunTest_WithLongPassword_Impl<ManagedPbkdf2Provider>();
+        }
+
+        [ConditionalFact]
+        [ConditionalRunTestOnlyIfBcryptAvailable("BCryptDeriveKeyPBKDF2")]
+        public void RunTest_WithLongPassword_Win7()
+        {
+            RunTest_WithLongPassword_Impl<Win7Pbkdf2Provider>();
+        }
+
+        [ConditionalFact]
+        [ConditionalRunTestOnlyIfBcryptAvailable("BCryptKeyDerivation")]
+        public void RunTest_WithLongPassword_Win8()
+        {
+            RunTest_WithLongPassword_Impl<Win8Pbkdf2Provider>();
+        }
+
+        private static void RunTest_WithLongPassword_Impl<TProvider>()
+            where TProvider : IPbkdf2Provider, new()
         {
             // Arrange
             string password = new String('x', 50000); // 50,000 char password
@@ -49,10 +122,8 @@ namespace Microsoft.AspNet.Security.DataProtection.Test.PBKDF2
             const int iterationCount = 5;
             const int numBytesRequested = 128;
 
-            // Act & assert - fully managed, Win7, and Win8
-            TestProvider<ManagedPbkdf2Provider>(password, salt, prf, iterationCount, numBytesRequested, expectedDerivedKeyBase64);
-            TestProvider<Win7Pbkdf2Provider>(password, salt, prf, iterationCount, numBytesRequested, expectedDerivedKeyBase64);
-            TestProvider<Win8Pbkdf2Provider>(password, salt, prf, iterationCount, numBytesRequested, expectedDerivedKeyBase64);
+            // Act & assert
+            TestProvider<TProvider>(password, salt, prf, iterationCount, numBytesRequested, expectedDerivedKeyBase64);
         }
 
         private static void TestProvider<TProvider>(string password, byte[] salt, KeyDerivationPrf prf, int iterationCount, int numBytesRequested, string expectedDerivedKeyAsBase64)

--- a/test/Microsoft.AspNet.Security.DataProtection.Test/project.json
+++ b/test/Microsoft.AspNet.Security.DataProtection.Test/project.json
@@ -1,6 +1,7 @@
 {
     "dependencies": {
         "Microsoft.AspNet.Security.DataProtection": "1.0.0-*",
+        "Microsoft.AspNet.Testing": "1.0.0-*",
         "Moq": "4.2.1312.1622",
         "xunit.runner.kre": "1.0.0-*"
     },


### PR DESCRIPTION
@victorhurdugaci - this replaces https://github.com/aspnet/DataProtection/pull/42.  The primary difference is that this is conditioned on "does the OS support the p/invoke feature I'm about to use?" rather than trying to whitelist / blacklist OSes.
