### PR TITLE
Fixing dataprotection on IIS

### DIFF
--- a/src/Microsoft.AspNet.DataProtection/DataProtectionServices.cs
+++ b/src/Microsoft.AspNet.DataProtection/DataProtectionServices.cs
@@ -89,6 +89,7 @@ namespace Microsoft.Framework.DependencyInjection
                         {
                             // If the user profile isn't available, we can protect using DPAPI (to machine).
                             keyEncryptorDescriptor = DataProtectionServiceDescriptors.IXmlEncryptor_Dpapi(protectToMachine: true);
+                            keyRepositoryDescriptor = DataProtectionServiceDescriptors.IXmlRepository_Registry(regKeyStorageKey);
 
                             if (log.IsInformationLevelEnabled())
                             {

--- a/src/Microsoft.AspNet.DataProtection/Repositories/RegistryXmlRepository.cs
+++ b/src/Microsoft.AspNet.DataProtection/Repositories/RegistryXmlRepository.cs
@@ -91,8 +91,9 @@ namespace Microsoft.AspNet.DataProtection.Repositories
         {
             try
             {
+                var registryView = IntPtr.Size == 4 ? RegistryView.Registry32 : RegistryView.Registry64;
                 // Try reading the auto-generated machine key from HKLM
-                using (var hklmBaseKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32))
+                using (var hklmBaseKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, registryView))
                 {
                     // Even though this is in HKLM, WAS ensures that applications hosted in IIS are properly isolated.
                     // See APP_POOL::EnsureSharedMachineKeyStorage in WAS source for more info.


### PR DESCRIPTION
Fixes: https://github.com/aspnet/DataProtection/issues/73

On IIS where there is no user profile, the code tries to always read the 32bit registry view irrespective of the bitness of the worker process. So in case of 64 bit app pools the registry key is null so it falls back to in memory ephemeral repository. On 32 bit app pool it can find an appropriate registry key, but the keyRepositoryDescriptor is not populated resulting in a null reference exception.

Current behavior:
X86 throws
X64 falls back to in memory ephemeral

With fix:
Both X86 and X64 will use DPAPI.

@davidfowl @ChengTian @glennc @anurse @muratg 