### PR TITLE
Fixed possibly wrong registry path

### DIFF
--- a/Provision-AutoGenKeys.ps1
+++ b/Provision-AutoGenKeys.ps1
@@ -43,10 +43,10 @@ function Provision-AutoGenKeys {
         $aspNetKey = $softwareMicrosoftKey.CreateSubKey("ASP.NET")
     }
 
-    $aspNetBaseKey = $softwareMicrosoftKey.OpenSubKey("$expandedVersion", $True);
+    $aspNetBaseKey = $aspNetKey.OpenSubKey("$expandedVersion", $True);
     if ($aspNetBaseKey -eq $null)
     {
-        $aspNetBaseKey = $softwareMicrosoftKey.CreateSubKey("$expandedVersion")
+        $aspNetBaseKey = $aspNetKey.CreateSubKey("$expandedVersion")
     }
 
     # Create AutoGenKeys subkey if it doesn't already exist


### PR DESCRIPTION
Your version of this script opens/creates registry path "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\4.0.30319.0\AutoGenKeys\$sid"
I think the correct path should be "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\ASP.NET\4.0.30319.0\AutoGenKeys\$sid"