### PR TITLE
Set IXmlRepository using ConfigureOptions

### DIFF
--- a/src/Microsoft.AspNetCore.DataProtection.AzureStorage/AzureDataProtectionBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.DataProtection.AzureStorage/AzureDataProtectionBuilderExtensions.cs
@@ -3,7 +3,7 @@
 
 using System;
 using Microsoft.AspNetCore.DataProtection.AzureStorage;
-using Microsoft.AspNetCore.DataProtection.Repositories;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Auth;
@@ -163,10 +163,13 @@ namespace Microsoft.AspNetCore.DataProtection
         }
 
         // important: the Func passed into this method must return a new instance with each call
-        private static IDataProtectionBuilder PersistKeystoAzureBlobStorageInternal(IDataProtectionBuilder config, Func<CloudBlockBlob> blobRefFactory)
+        private static IDataProtectionBuilder PersistKeystoAzureBlobStorageInternal(IDataProtectionBuilder builder, Func<CloudBlockBlob> blobRefFactory)
         {
-            config.Services.AddSingleton<IXmlRepository>(services => new AzureBlobXmlRepository(blobRefFactory));
-            return config;
+            builder.Services.Configure<KeyManagementOptions>(options =>
+            {
+                options.XmlRepository = new AzureBlobXmlRepository(blobRefFactory);
+            });
+            return builder;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.DataProtection.Redis/RedisDataProtectionBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.DataProtection.Redis/RedisDataProtectionBuilderExtensions.cs
@@ -3,8 +3,8 @@
 
 using System;
 using StackExchange.Redis;
-using Microsoft.AspNetCore.DataProtection.Repositories;
-using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.DataProtection
 {
@@ -66,10 +66,13 @@ namespace Microsoft.AspNetCore.DataProtection
             return PersistKeysToRedisInternal(builder, () => connectionMultiplexer.GetDatabase(), key);
         }
 
-        private static IDataProtectionBuilder PersistKeysToRedisInternal(IDataProtectionBuilder config, Func<IDatabase> databaseFactory, RedisKey key)
+        private static IDataProtectionBuilder PersistKeysToRedisInternal(IDataProtectionBuilder builder, Func<IDatabase> databaseFactory, RedisKey key)
         {
-            config.Services.TryAddSingleton<IXmlRepository>(services => new RedisXmlRepository(databaseFactory, key));
-            return config;
+            builder.Services.Configure<KeyManagementOptions>(options =>
+            {
+                options.XmlRepository = new RedisXmlRepository(databaseFactory, key);
+            });
+            return builder;
         }
     }
 }

--- a/test/Microsoft.AspNetCore.DataProtection.AzureStorage.Test/AzureDataProtectionBuilderExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.DataProtection.AzureStorage.Test/AzureDataProtectionBuilderExtensionsTest.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.WindowsAzure.Storage.Blob;
+using Xunit;
+
+namespace Microsoft.AspNetCore.DataProtection.AzureStorage
+{
+    public class AzureDataProtectionBuilderExtensionsTest
+    {
+        [Fact]
+        public void PersistKeysToAzureBlobStorage_UsesAzureBlobXmlRepository()
+        {
+            // Arrange
+            var container = new CloudBlobContainer(new Uri("http://www.example.com"));
+            var serviceCollection = new ServiceCollection();
+            var builder = serviceCollection.AddDataProtection();
+
+            // Act
+            builder.PersistKeysToAzureBlobStorage(container, "keys.xml");
+            var services = serviceCollection.BuildServiceProvider();
+
+            // Assert
+            var options = services.GetRequiredService<IOptions<KeyManagementOptions>>();
+            Assert.IsType<AzureBlobXmlRepository>(options.Value.XmlRepository);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.DataProtection.Redis.Test/Microsoft.AspNetCore.DataProtection.Redis.Test.csproj
+++ b/test/Microsoft.AspNetCore.DataProtection.Redis.Test/Microsoft.AspNetCore.DataProtection.Redis.Test.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.DataProtection.Abstractions\Microsoft.AspNetCore.DataProtection.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.DataProtection.Redis\Microsoft.AspNetCore.DataProtection.Redis.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.Testing" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />

--- a/test/Microsoft.AspNetCore.DataProtection.Redis.Test/RedisDataProtectionBuilderExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.DataProtection.Redis.Test/RedisDataProtectionBuilderExtensionsTest.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Microsoft.AspNetCore.DataProtection.Redis
+{
+    public class RedisDataProtectionBuilderExtensionsTest
+    {
+        [Fact]
+        public void PersistKeysToRedis_UsesRedisXmlRepository()
+        {
+            // Arrange
+            var connection = Mock.Of<IConnectionMultiplexer>();
+            var serviceCollection = new ServiceCollection();
+            var builder = serviceCollection.AddDataProtection();
+
+            // Act
+            builder.PersistKeysToRedis(connection);
+            var services = serviceCollection.BuildServiceProvider();
+
+            // Assert
+            var options = services.GetRequiredService<IOptions<KeyManagementOptions>>();
+            Assert.IsType<RedisXmlRepository>(options.Value.XmlRepository);
+        }
+    }
+}


### PR DESCRIPTION
Issue - #218 

This is the output of the sample after this change,

```
dbug: Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager[18]
      Found key {c5125edb-70b6-4e41-b4d8-8de8127812bf}.
dbug: Microsoft.AspNetCore.DataProtection.KeyManagement.DefaultKeyResolver[13]
      Considering key {c5125edb-70b6-4e41-b4d8-8de8127812bf} with expiration date 2017-07-04 19:30:00Z as default key.
dbug: Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.CngCbcAuthenticatedEncryptorFactory[4]
      Opening CNG algorithm 'AES' from provider '(null)' with chaining mode CBC.
dbug: Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.CngCbcAuthenticatedEncryptorFactory[3]
      Opening CNG algorithm 'SHA256' from provider '(null)' with HMAC.
dbug: Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.CngCbcAuthenticatedEncryptorFactory[4]
      Opening CNG algorithm 'AES' from provider '(null)' with chaining mode CBC.
dbug: Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.CngCbcAuthenticatedEncryptorFactory[3]
      Opening CNG algorithm 'SHA256' from provider '(null)' with HMAC.
dbug: Microsoft.AspNetCore.DataProtection.KeyManagement.KeyRingProvider[2]
      Using key {c5125edb-70b6-4e41-b4d8-8de8127812bf} as the default key.
dbug: Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.CngCbcAuthenticatedEncryptorFactory[4]
      Opening CNG algorithm 'AES' from provider '(null)' with chaining mode CBC.
dbug: Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.CngCbcAuthenticatedEncryptorFactory[3]
      Opening CNG algorithm 'SHA256' from provider '(null)' with HMAC.
trce: Microsoft.AspNetCore.DataProtection.KeyManagement.KeyRingBasedDataProtector[31]
      Performing protect operation to key {c5125edb-70b6-4e41-b4d8-8de8127812bf} with purposes ('sample-purpose').
CfDJ8NteEsW2cEFOtNiN6BJ4Er8_XioPI4dY5PhqFVzCzOifKCTi8X6zqTAopL58e6igrJOS1hUkwkjOx3dI4iPQ4h7mnrxBesq26LzKaFLAwEKHDaNet0hrMA6iaoYXOHhGYQ
```

I am currently investigating why `CngCbcAuthenticatedEncryptorFactory` is called multiple times. But that shouldn't block this PR. 