### PR TITLE
Creating only one IAuthenticatedEncryptor per IKey

### DIFF
--- a/src/Microsoft.AspNetCore.DataProtection/KeyManagement/DefaultKeyResolver.cs
+++ b/src/Microsoft.AspNetCore.DataProtection/KeyManagement/DefaultKeyResolver.cs
@@ -29,8 +29,6 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
 
         private readonly ILogger _logger;
 
-        private readonly IEnumerable<IAuthenticatedEncryptorFactory> _encryptorFactories;
-
         /// <summary>
         /// The maximum skew that is allowed between servers.
         /// This is used to allow newly-created keys to be used across servers even though
@@ -46,7 +44,6 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
         {
             _keyPropagationWindow = keyManagementOptions.Value.KeyPropagationWindow;
             _maxServerToServerClockSkew = keyManagementOptions.Value.MaxServerClockSkew;
-            _encryptorFactories = keyManagementOptions.Value.AuthenticatedEncryptorFactories;
             _logger = loggerFactory.CreateLogger<DefaultKeyResolver>();
         }
 
@@ -54,16 +51,7 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
         {
             try
             {
-                IAuthenticatedEncryptor encryptorInstance = null;
-                foreach (var factory in _encryptorFactories)
-                {
-                    encryptorInstance = factory.CreateEncryptorInstance(key);
-                    if (encryptorInstance != null)
-                    {
-                        break;
-                    }
-                }
-
+                var encryptorInstance = key.CreateEncryptor();
                 if (encryptorInstance == null)
                 {
                     CryptoUtil.Fail<IAuthenticatedEncryptor>("CreateEncryptorInstance returned null.");
@@ -73,7 +61,7 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
             }
             catch (Exception ex)
             {
-                _logger.KeyIsIneligibleToBeTheDefaultKeyBecauseItsMethodFailed(key.KeyId, nameof(IAuthenticatedEncryptorFactory.CreateEncryptorInstance), ex);
+                _logger.KeyIsIneligibleToBeTheDefaultKeyBecauseItsMethodFailed(key.KeyId, nameof(IKey.CreateEncryptor), ex);
                 return false;
             }
         }

--- a/src/Microsoft.AspNetCore.DataProtection/KeyManagement/DeferredKey.cs
+++ b/src/Microsoft.AspNetCore.DataProtection/KeyManagement/DeferredKey.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Xml.Linq;
+using Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption;
 using Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel;
 using Microsoft.AspNetCore.DataProtection.KeyManagement.Internal;
 using Microsoft.AspNetCore.DataProtection.XmlEncryption;
@@ -21,8 +23,14 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
             DateTimeOffset activationDate,
             DateTimeOffset expirationDate,
             IInternalXmlKeyManager keyManager,
-            XElement keyElement)
-            : base(keyId, creationDate, activationDate, expirationDate, new Lazy<IAuthenticatedEncryptorDescriptor>(GetLazyDescriptorDelegate(keyManager, keyElement)))
+            XElement keyElement,
+            IEnumerable<IAuthenticatedEncryptorFactory> encryptorFactories)
+            : base(keyId,
+                  creationDate,
+                  activationDate,
+                  expirationDate,
+                  new Lazy<IAuthenticatedEncryptorDescriptor>(GetLazyDescriptorDelegate(keyManager, keyElement)),
+                  encryptorFactories)
         {
         }
 

--- a/src/Microsoft.AspNetCore.DataProtection/KeyManagement/IKey.cs
+++ b/src/Microsoft.AspNetCore.DataProtection/KeyManagement/IKey.cs
@@ -49,5 +49,12 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
         /// Gets the <see cref="IAuthenticatedEncryptorDescriptor"/> instance associated with this key.
         /// </summary>
         IAuthenticatedEncryptorDescriptor Descriptor { get; }
+
+        /// <summary>
+        /// Creates an <see cref="IAuthenticatedEncryptor"/> instance that can be used to encrypt data
+        /// to and decrypt data from this key.
+        /// </summary>
+        /// <returns>An <see cref="IAuthenticatedEncryptor"/>.</returns>
+        IAuthenticatedEncryptor CreateEncryptor();
     }
 }

--- a/src/Microsoft.AspNetCore.DataProtection/KeyManagement/Internal/CacheableKeyRing.cs
+++ b/src/Microsoft.AspNetCore.DataProtection/KeyManagement/Internal/CacheableKeyRing.cs
@@ -15,8 +15,8 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement.Internal
     {
         private readonly CancellationToken _expirationToken;
 
-        internal CacheableKeyRing(CancellationToken expirationToken, DateTimeOffset expirationTime, IKey defaultKey, IEnumerable<IKey> allKeys, IEnumerable<IAuthenticatedEncryptorFactory> encryptorFactories)
-            : this(expirationToken, expirationTime, keyRing: new KeyRing(defaultKey, allKeys, encryptorFactories))
+        internal CacheableKeyRing(CancellationToken expirationToken, DateTimeOffset expirationTime, IKey defaultKey, IEnumerable<IKey> allKeys)
+            : this(expirationToken, expirationTime, keyRing: new KeyRing(defaultKey, allKeys))
         {
         }
 

--- a/src/Microsoft.AspNetCore.DataProtection/KeyManagement/Internal/DefaultKeyResolution.cs
+++ b/src/Microsoft.AspNetCore.DataProtection/KeyManagement/Internal/DefaultKeyResolution.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement.Internal
         /// The default key, may be null if no key is a good default candidate.
         /// </summary>
         /// <remarks>
-        /// If this property is non-null, its <see cref="IAuthenticatedEncryptorFactory.CreateEncryptorInstance(IKey)"/> method will succeed
+        /// If this property is non-null, its <see cref="IKey.CreateEncryptor()"/> method will succeed
         /// so is appropriate for use with deferred keys.
         /// </remarks>
         public IKey DefaultKey;
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement.Internal
         /// be null if there is no viable fallback key.
         /// </summary>
         /// <remarks>
-        /// If this property is non-null, its <see cref="IAuthenticatedEncryptorFactory.CreateEncryptorInstance(IKey)"/> method will succeed
+        /// If this property is non-null, its <see cref="IKey.CreateEncryptor()"/> method will succeed
         /// so is appropriate for use with deferred keys.
         /// </remarks>
         public IKey FallbackKey;

--- a/src/Microsoft.AspNetCore.DataProtection/KeyManagement/Key.cs
+++ b/src/Microsoft.AspNetCore.DataProtection/KeyManagement/Key.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption;
 using Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel;
 
@@ -13,8 +14,19 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
     /// </summary>
     internal sealed class Key : KeyBase
     {
-        public Key(Guid keyId, DateTimeOffset creationDate, DateTimeOffset activationDate, DateTimeOffset expirationDate, IAuthenticatedEncryptorDescriptor descriptor)
-            : base(keyId, creationDate, activationDate, expirationDate, new Lazy<IAuthenticatedEncryptorDescriptor>(() => descriptor))
+        public Key(
+            Guid keyId,
+            DateTimeOffset creationDate,
+            DateTimeOffset activationDate,
+            DateTimeOffset expirationDate,
+            IAuthenticatedEncryptorDescriptor descriptor,
+            IEnumerable<IAuthenticatedEncryptorFactory> encryptorFactories)
+            : base(keyId,
+                  creationDate,
+                  activationDate,
+                  expirationDate,
+                  new Lazy<IAuthenticatedEncryptorDescriptor>(() => descriptor),
+                  encryptorFactories)
         {
         }
     }

--- a/src/Microsoft.AspNetCore.DataProtection/KeyManagement/XmlKeyManager.cs
+++ b/src/Microsoft.AspNetCore.DataProtection/KeyManagement/XmlKeyManager.cs
@@ -12,6 +12,7 @@ using System.Xml;
 using System.Xml.Linq;
 using Microsoft.AspNetCore.Cryptography;
 using Microsoft.AspNetCore.Cryptography.Cng;
+using Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption;
 using Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel;
 using Microsoft.AspNetCore.DataProtection.Cng;
 using Microsoft.AspNetCore.DataProtection.Internal;
@@ -50,6 +51,7 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
         private readonly IInternalXmlKeyManager _internalKeyManager;
         private readonly ILoggerFactory _loggerFactory;
         private readonly ILogger _logger;
+        private readonly IEnumerable<IAuthenticatedEncryptorFactory> _encryptorFactories;
 
         private CancellationTokenSource _cacheExpirationTokenSource;
 
@@ -88,6 +90,7 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
             _activator = activator;
             TriggerAndResetCacheExpirationToken(suppressLogging: true);
             _internalKeyManager = _internalKeyManager ?? this;
+            _encryptorFactories = keyManagementOptions.Value.AuthenticatedEncryptorFactories;
         }
 
         // Internal for testing.
@@ -240,7 +243,8 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
                     activationDate: activationDate,
                     expirationDate: expirationDate,
                     keyManager: this,
-                    keyElement: keyElement);
+                    keyElement: keyElement,
+                    encryptorFactories: _encryptorFactories);
             }
             catch (Exception ex)
             {
@@ -400,7 +404,8 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
                 creationDate: creationDate,
                 activationDate: activationDate,
                 expirationDate: expirationDate,
-                descriptor: newDescriptor);
+                descriptor: newDescriptor,
+                encryptorFactories: _encryptorFactories);
         }
 
         IAuthenticatedEncryptorDescriptor IInternalXmlKeyManager.DeserializeDescriptorFromKeyElement(XElement keyElement)

--- a/test/Microsoft.AspNetCore.DataProtection.Test/AuthenticatedEncryption/ConfigurationModel/AuthenticatedEncryptorDescriptorDeserializerTests.cs
+++ b/test/Microsoft.AspNetCore.DataProtection.Test/AuthenticatedEncryption/ConfigurationModel/AuthenticatedEncryptorDescriptorDeserializerTests.cs
@@ -43,16 +43,17 @@ namespace Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.Configurat
 
         private static IAuthenticatedEncryptor CreateEncryptorInstanceFromDescriptor(AuthenticatedEncryptorDescriptor descriptor)
         {
+            var encryptorFactory = new AuthenticatedEncryptorFactory(NullLoggerFactory.Instance);
             var key = new Key(
                 Guid.NewGuid(),
                 DateTimeOffset.Now,
                 DateTimeOffset.Now + TimeSpan.FromHours(1),
                 DateTimeOffset.Now + TimeSpan.FromDays(30),
-                descriptor);
+                descriptor,
+                new[] { encryptorFactory });
 
-            var encryptorFactory = new AuthenticatedEncryptorFactory(NullLoggerFactory.Instance);
 
-            return encryptorFactory.CreateEncryptorInstance(key);
+            return key.CreateEncryptor();
         }
     }
 }

--- a/test/Microsoft.AspNetCore.DataProtection.Test/AuthenticatedEncryption/ConfigurationModel/AuthenticatedEncryptorDescriptorTests.cs
+++ b/test/Microsoft.AspNetCore.DataProtection.Test/AuthenticatedEncryption/ConfigurationModel/AuthenticatedEncryptorDescriptorTests.cs
@@ -171,17 +171,19 @@ namespace Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.Configurat
 
         private static IAuthenticatedEncryptor CreateEncryptorInstanceFromDescriptor(AuthenticatedEncryptorDescriptor descriptor)
         {
+            var encryptorFactory = new AuthenticatedEncryptorFactory(NullLoggerFactory.Instance);
+
             // Dummy key with the specified descriptor.
             var key = new Key(
                 Guid.NewGuid(),
                 DateTimeOffset.Now,
                 DateTimeOffset.Now + TimeSpan.FromHours(1),
                 DateTimeOffset.Now + TimeSpan.FromDays(30),
-                descriptor);
+                descriptor,
+                new[] { encryptorFactory });
 
-            var encryptorFactory = new AuthenticatedEncryptorFactory(NullLoggerFactory.Instance);
 
-            return encryptorFactory.CreateEncryptorInstance(key);
+            return key.CreateEncryptor();
         }
     }
 }

--- a/test/Microsoft.AspNetCore.DataProtection.Test/AuthenticatedEncryption/ConfigurationModel/CngCbcAuthenticatedEncryptorDescriptorDeserializerTests.cs
+++ b/test/Microsoft.AspNetCore.DataProtection.Test/AuthenticatedEncryption/ConfigurationModel/CngCbcAuthenticatedEncryptorDescriptorDeserializerTests.cs
@@ -50,16 +50,17 @@ namespace Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.Configurat
 
         private static IAuthenticatedEncryptor CreateEncryptorInstanceFromDescriptor(CngCbcAuthenticatedEncryptorDescriptor descriptor)
         {
+            var encryptorFactory = new CngCbcAuthenticatedEncryptorFactory(NullLoggerFactory.Instance);
             var key = new Key(
                 Guid.NewGuid(),
                 DateTimeOffset.Now,
                 DateTimeOffset.Now + TimeSpan.FromHours(1),
                 DateTimeOffset.Now + TimeSpan.FromDays(30),
-                descriptor);
+                descriptor,
+                new[] { encryptorFactory });
 
-            var encryptorFactory = new CngCbcAuthenticatedEncryptorFactory(NullLoggerFactory.Instance);
 
-            return encryptorFactory.CreateEncryptorInstance(key);
+            return key.CreateEncryptor();
         }
     }
 }

--- a/test/Microsoft.AspNetCore.DataProtection.Test/AuthenticatedEncryption/ConfigurationModel/CngGcmAuthenticatedEncryptorDescriptorDeserializerTests.cs
+++ b/test/Microsoft.AspNetCore.DataProtection.Test/AuthenticatedEncryption/ConfigurationModel/CngGcmAuthenticatedEncryptorDescriptorDeserializerTests.cs
@@ -47,16 +47,17 @@ namespace Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.Configurat
 
         private static IAuthenticatedEncryptor CreateEncryptorInstanceFromDescriptor(CngGcmAuthenticatedEncryptorDescriptor descriptor)
         {
+            var encryptorFactory = new CngGcmAuthenticatedEncryptorFactory(NullLoggerFactory.Instance);
             var key = new Key(
                 keyId: Guid.NewGuid(),
                 creationDate: DateTimeOffset.Now,
                 activationDate: DateTimeOffset.Now + TimeSpan.FromHours(1),
                 expirationDate: DateTimeOffset.Now + TimeSpan.FromDays(30),
-                descriptor: descriptor);
+                descriptor: descriptor,
+                encryptorFactories: new[] { encryptorFactory });
 
-            var encryptorFactory = new CngGcmAuthenticatedEncryptorFactory(NullLoggerFactory.Instance);
 
-            return encryptorFactory.CreateEncryptorInstance(key);
+            return key.CreateEncryptor();
         }
     }
 }

--- a/test/Microsoft.AspNetCore.DataProtection.Test/AuthenticatedEncryption/ConfigurationModel/ManagedAuthenticatedEncryptorDescriptorDeserializerTests.cs
+++ b/test/Microsoft.AspNetCore.DataProtection.Test/AuthenticatedEncryption/ConfigurationModel/ManagedAuthenticatedEncryptorDescriptorDeserializerTests.cs
@@ -86,16 +86,16 @@ namespace Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.Configurat
 
         private static IAuthenticatedEncryptor CreateEncryptorInstanceFromDescriptor(ManagedAuthenticatedEncryptorDescriptor descriptor)
         {
+            var encryptorFactory = new ManagedAuthenticatedEncryptorFactory(NullLoggerFactory.Instance);
             var key = new Key(
                 Guid.NewGuid(),
                 DateTimeOffset.Now,
                 DateTimeOffset.Now + TimeSpan.FromHours(1),
                 DateTimeOffset.Now + TimeSpan.FromDays(30),
-                descriptor);
+                descriptor,
+                new[] { encryptorFactory });
 
-            var encryptorFactory = new ManagedAuthenticatedEncryptorFactory(NullLoggerFactory.Instance);
-
-            return encryptorFactory.CreateEncryptorInstance(key);
+            return key.CreateEncryptor();
         }
     }
 }

--- a/test/Microsoft.AspNetCore.DataProtection.Test/KeyManagement/DeferredKeyTests.cs
+++ b/test/Microsoft.AspNetCore.DataProtection.Test/KeyManagement/DeferredKeyTests.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
+using Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption;
 
 namespace Microsoft.AspNetCore.DataProtection.KeyManagement
 {
@@ -30,10 +31,10 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
                     XmlAssert.Equal(@"<node />", element);
                     return mockDescriptor;
                 });
-            var options = Options.Create(new KeyManagementOptions());
+            var encryptorFactory = Mock.Of<IAuthenticatedEncryptorFactory>();
 
             // Act
-            var key = new DeferredKey(keyId, creationDate, activationDate, expirationDate, mockInternalKeyManager.Object, XElement.Parse(@"<node />"));
+            var key = new DeferredKey(keyId, creationDate, activationDate, expirationDate, mockInternalKeyManager.Object, XElement.Parse(@"<node />"), new[] { encryptorFactory });
 
             // Assert
             Assert.Equal(keyId, key.KeyId);
@@ -48,8 +49,8 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
         {
             // Arrange
             var now = DateTimeOffset.UtcNow;
-            var options = Options.Create(new KeyManagementOptions());
-            var key = new DeferredKey(Guid.Empty, now, now, now, new Mock<IInternalXmlKeyManager>().Object, XElement.Parse(@"<node />"));
+            var encryptorFactory = Mock.Of<IAuthenticatedEncryptorFactory>();
+            var key = new DeferredKey(Guid.Empty, now, now, now, new Mock<IInternalXmlKeyManager>().Object, XElement.Parse(@"<node />"), new[] { encryptorFactory });
 
             // Act & assert
             Assert.False(key.IsRevoked);
@@ -71,7 +72,8 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
                 });
 
             var now = DateTimeOffset.UtcNow;
-            var key = new DeferredKey(Guid.Empty, now, now, now, mockKeyManager.Object, XElement.Parse(@"<node />"));
+            var encryptorFactory = Mock.Of<IAuthenticatedEncryptorFactory>();
+            var key = new DeferredKey(Guid.Empty, now, now, now, mockKeyManager.Object, XElement.Parse(@"<node />"), new[] { encryptorFactory });
 
             // Act & assert
             ExceptionAssert.Throws<Exception>(() => key.Descriptor, "How exceptional.");

--- a/test/Microsoft.AspNetCore.DataProtection.Test/KeyManagement/KeyRingBasedDataProtectorTests.cs
+++ b/test/Microsoft.AspNetCore.DataProtection.Test/KeyManagement/KeyRingBasedDataProtectorTests.cs
@@ -208,8 +208,8 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
             var encryptorFactory = new AuthenticatedEncryptorFactory(NullLoggerFactory.Instance);
 
             // the keyring has only one key
-            Key key = new Key(Guid.Empty, DateTimeOffset.Now, DateTimeOffset.Now, DateTimeOffset.Now, mockDescriptor.Object);
-            var keyRing = new KeyRing(key, new[] { key }, new[] { mockEncryptorFactory.Object });
+            Key key = new Key(Guid.Empty, DateTimeOffset.Now, DateTimeOffset.Now, DateTimeOffset.Now, mockDescriptor.Object, new[] { mockEncryptorFactory.Object });
+            var keyRing = new KeyRing(key, new[] { key });
             var mockKeyRingProvider = new Mock<IKeyRingProvider>();
             mockKeyRingProvider.Setup(o => o.GetCurrentKeyRing()).Returns(keyRing);
 
@@ -238,9 +238,9 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
             mockEncryptorFactory.Setup(o => o.CreateEncryptorInstance(It.IsAny<IKey>())).Returns(new Mock<IAuthenticatedEncryptor>().Object);
 
             // the keyring has only one key
-            Key key = new Key(keyId, DateTimeOffset.Now, DateTimeOffset.Now, DateTimeOffset.Now, mockDescriptor.Object);
+            Key key = new Key(keyId, DateTimeOffset.Now, DateTimeOffset.Now, DateTimeOffset.Now, mockDescriptor.Object, new[] { mockEncryptorFactory.Object });
             key.SetRevoked();
-            var keyRing = new KeyRing(key, new[] { key }, new[] { mockEncryptorFactory.Object });
+            var keyRing = new KeyRing(key, new[] { key });
             var mockKeyRingProvider = new Mock<IKeyRingProvider>();
             mockKeyRingProvider.Setup(o => o.GetCurrentKeyRing()).Returns(keyRing);
 
@@ -278,9 +278,9 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
             var mockEncryptorFactory = new Mock<IAuthenticatedEncryptorFactory>();
             mockEncryptorFactory.Setup(o => o.CreateEncryptorInstance(It.IsAny<IKey>())).Returns(mockEncryptor.Object);
 
-            Key defaultKey = new Key(defaultKeyId, DateTimeOffset.Now, DateTimeOffset.Now, DateTimeOffset.Now, mockDescriptor.Object);
+            Key defaultKey = new Key(defaultKeyId, DateTimeOffset.Now, DateTimeOffset.Now, DateTimeOffset.Now, mockDescriptor.Object, new[] { mockEncryptorFactory.Object });
             defaultKey.SetRevoked();
-            var keyRing = new KeyRing(defaultKey, new[] { defaultKey }, new[] { mockEncryptorFactory.Object });
+            var keyRing = new KeyRing(defaultKey, new[] { defaultKey });
             var mockKeyRingProvider = new Mock<IKeyRingProvider>();
             mockKeyRingProvider.Setup(o => o.GetCurrentKeyRing()).Returns(keyRing);
 
@@ -326,8 +326,8 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
             var mockEncryptorFactory = new Mock<IAuthenticatedEncryptorFactory>();
             mockEncryptorFactory.Setup(o => o.CreateEncryptorInstance(It.IsAny<IKey>())).Returns(mockEncryptor.Object);
 
-            Key defaultKey = new Key(defaultKeyId, DateTimeOffset.Now, DateTimeOffset.Now, DateTimeOffset.Now, mockDescriptor.Object);
-            var keyRing = new KeyRing(defaultKey, new[] { defaultKey }, new[] { mockEncryptorFactory.Object });
+            Key defaultKey = new Key(defaultKeyId, DateTimeOffset.Now, DateTimeOffset.Now, DateTimeOffset.Now, mockDescriptor.Object, new[] { mockEncryptorFactory.Object });
+            var keyRing = new KeyRing(defaultKey, new[] { defaultKey });
             var mockKeyRingProvider = new Mock<IKeyRingProvider>();
             mockKeyRingProvider.Setup(o => o.GetCurrentKeyRing()).Returns(keyRing);
 
@@ -376,9 +376,9 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
             var mockEncryptorFactory = new Mock<IAuthenticatedEncryptorFactory>();
             mockEncryptorFactory.Setup(o => o.CreateEncryptorInstance(It.IsAny<IKey>())).Returns(mockEncryptor.Object);
 
-            Key defaultKey = new Key(defaultKeyId, DateTimeOffset.Now, DateTimeOffset.Now, DateTimeOffset.Now, new Mock<IAuthenticatedEncryptorDescriptor>().Object);
-            Key embeddedKey = new Key(embeddedKeyId, DateTimeOffset.Now, DateTimeOffset.Now, DateTimeOffset.Now, mockDescriptor.Object);
-            var keyRing = new KeyRing(defaultKey, new[] { defaultKey, embeddedKey }, new[] { mockEncryptorFactory.Object });
+            Key defaultKey = new Key(defaultKeyId, DateTimeOffset.Now, DateTimeOffset.Now, DateTimeOffset.Now, new Mock<IAuthenticatedEncryptorDescriptor>().Object, new[] { mockEncryptorFactory.Object });
+            Key embeddedKey = new Key(embeddedKeyId, DateTimeOffset.Now, DateTimeOffset.Now, DateTimeOffset.Now, mockDescriptor.Object, new[] { mockEncryptorFactory.Object });
+            var keyRing = new KeyRing(defaultKey, new[] { defaultKey, embeddedKey });
             var mockKeyRingProvider = new Mock<IKeyRingProvider>();
             mockKeyRingProvider.Setup(o => o.GetCurrentKeyRing()).Returns(keyRing);
 
@@ -408,9 +408,9 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
         {
             // Arrange
             byte[] plaintext = new byte[] { 0x10, 0x20, 0x30, 0x40, 0x50 };
-            Key key = new Key(Guid.NewGuid(), DateTimeOffset.Now, DateTimeOffset.Now, DateTimeOffset.Now, new AuthenticatedEncryptorConfiguration().CreateNewDescriptor());
             var encryptorFactory = new AuthenticatedEncryptorFactory(NullLoggerFactory.Instance);
-            var keyRing = new KeyRing(key, new[] { key }, new[] { encryptorFactory });
+            Key key = new Key(Guid.NewGuid(), DateTimeOffset.Now, DateTimeOffset.Now, DateTimeOffset.Now, new AuthenticatedEncryptorConfiguration().CreateNewDescriptor(), new[] { encryptorFactory });
+            var keyRing = new KeyRing(key, new[] { key });
             var mockKeyRingProvider = new Mock<IKeyRingProvider>();
             mockKeyRingProvider.Setup(o => o.GetCurrentKeyRing()).Returns(keyRing);
 

--- a/test/Microsoft.AspNetCore.DataProtection.Test/KeyManagement/KeyRingProviderTests.cs
+++ b/test/Microsoft.AspNetCore.DataProtection.Test/KeyManagement/KeyRingProviderTests.cs
@@ -644,6 +644,7 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
             mockKey.Setup(o => o.ExpirationDate).Returns(DateTimeOffset.ParseExact(expirationDate, "u", CultureInfo.InvariantCulture));
             mockKey.Setup(o => o.IsRevoked).Returns(isRevoked);
             mockKey.Setup(o => o.Descriptor).Returns(new Mock<IAuthenticatedEncryptorDescriptor>().Object);
+            mockKey.Setup(o => o.CreateEncryptor()).Returns(new Mock<IAuthenticatedEncryptor>().Object);
             return mockKey.Object;
         }
     }

--- a/test/Microsoft.AspNetCore.DataProtection.Test/KeyManagement/KeyTests.cs
+++ b/test/Microsoft.AspNetCore.DataProtection.Test/KeyManagement/KeyTests.cs
@@ -5,6 +5,7 @@ using System;
 using Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel;
 using Moq;
 using Xunit;
+using Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption;
 
 namespace Microsoft.AspNetCore.DataProtection.KeyManagement
 {
@@ -19,9 +20,10 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
             var activationDate = creationDate.AddDays(2);
             var expirationDate = creationDate.AddDays(90);
             var descriptor = Mock.Of<IAuthenticatedEncryptorDescriptor>();
+            var encryptorFactory = Mock.Of<IAuthenticatedEncryptorFactory>();
 
             // Act
-            var key = new Key(keyId, creationDate, activationDate, expirationDate, descriptor);
+            var key = new Key(keyId, creationDate, activationDate, expirationDate, descriptor, new[] { encryptorFactory });
 
             // Assert
             Assert.Equal(keyId, key.KeyId);
@@ -36,7 +38,8 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
         {
             // Arrange
             var now = DateTimeOffset.UtcNow;
-            var key = new Key(Guid.Empty, now, now, now, new Mock<IAuthenticatedEncryptorDescriptor>().Object);
+            var encryptorFactory = Mock.Of<IAuthenticatedEncryptorFactory>();
+            var key = new Key(Guid.Empty, now, now, now, new Mock<IAuthenticatedEncryptorDescriptor>().Object, new[] { encryptorFactory });
 
             // Act & assert
             Assert.False(key.IsRevoked);


### PR DESCRIPTION
Issue - #220 

Problem:
We should be creating only one `IAuthenticatedEncryptor` instance per key. After #134, we now have multiple instances being created.

Solution:
Brought back `CreateEncryptorInstance()` on `IKey`

Why was this needed?
Currently `IKey` and `IAuthenticatedEncryptor` creation are decoupled. Because of that there was no way to associate an encryptor instance with a key. Having `CreateEncryptorInstance()` on `IKey` lets us use the same encryptor instance across multiple calls.

@rynowak 