### PR TITLE
Enable Api check and added breakingchanges json

### DIFF
--- a/src/Microsoft.AspNetCore.DataProtection/Microsoft.AspNetCore.DataProtection.csproj
+++ b/src/Microsoft.AspNetCore.DataProtection/Microsoft.AspNetCore.DataProtection.csproj
@@ -9,7 +9,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;dataprotection</PackageTags>
-    <EnableApiCheck>false</EnableApiCheck>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.DataProtection/breakingchanges.netcore.json
+++ b/src/Microsoft.AspNetCore.DataProtection/breakingchanges.netcore.json
@@ -1,0 +1,247 @@
+[
+  {
+    "TypeId": "public interface Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.IAuthenticatedEncryptorConfiguration",
+    "Kind": "Removal"
+  },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.AuthenticatedEncryptionSettings : Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.IInternalAuthenticatedEncryptionSettings",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.CngCbcAuthenticatedEncryptionSettings : Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.IInternalAuthenticatedEncryptionSettings",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.CngGcmAuthenticatedEncryptionSettings : Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.IInternalAuthenticatedEncryptionSettings",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorConfiguration : Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.IInternalAuthenticatedEncryptorConfiguration",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.CngCbcAuthenticatedEncryptorConfiguration : Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.IInternalAuthenticatedEncryptorConfiguration",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.CngGcmAuthenticatedEncryptorConfiguration : Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.IInternalAuthenticatedEncryptorConfiguration",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.ManagedAuthenticatedEncryptorConfiguration : Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.IInternalAuthenticatedEncryptorConfiguration",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ManagedAuthenticatedEncryptionSettings : Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.IInternalAuthenticatedEncryptionSettings",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public static class Microsoft.Extensions.DependencyInjection.DataProtectionServices",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.AspNetCore.DataProtection.KeyManagement.IKey",
+      "MemberId": "Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.IAuthenticatedEncryptor CreateEncryptorInstance()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.IAuthenticatedEncryptorDescriptor",
+      "MemberId": "Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.IAuthenticatedEncryptor CreateEncryptorInstance()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.AspNetCore.DataProtection.Repositories.FileSystemXmlRepository : Microsoft.AspNetCore.DataProtection.Repositories.IXmlRepository",
+      "MemberId": "protected System.IServiceProvider get_Services()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.AspNetCore.DataProtection.Repositories.FileSystemXmlRepository : Microsoft.AspNetCore.DataProtection.Repositories.IXmlRepository",
+      "MemberId": "public .ctor(System.IO.DirectoryInfo directory)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.AspNetCore.DataProtection.Repositories.FileSystemXmlRepository : Microsoft.AspNetCore.DataProtection.Repositories.IXmlRepository",
+      "MemberId": "public .ctor(System.IO.DirectoryInfo directory, System.IServiceProvider services)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.AspNetCore.DataProtection.Repositories.RegistryXmlRepository : Microsoft.AspNetCore.DataProtection.Repositories.IXmlRepository",
+      "MemberId": "protected System.IServiceProvider get_Services()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.AspNetCore.DataProtection.Repositories.RegistryXmlRepository : Microsoft.AspNetCore.DataProtection.Repositories.IXmlRepository",
+      "MemberId": "public .ctor(Microsoft.Win32.RegistryKey registryKey)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.AspNetCore.DataProtection.Repositories.RegistryXmlRepository : Microsoft.AspNetCore.DataProtection.Repositories.IXmlRepository",
+      "MemberId": "public .ctor(Microsoft.Win32.RegistryKey registryKey, System.IServiceProvider services)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.EphemeralDataProtectionProvider : Microsoft.AspNetCore.DataProtection.IDataProtectionProvider",
+      "MemberId": "public .ctor()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.EphemeralDataProtectionProvider : Microsoft.AspNetCore.DataProtection.IDataProtectionProvider",
+      "MemberId": "public .ctor(System.IServiceProvider services)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptor : Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.IAuthenticatedEncryptorDescriptor",
+      "MemberId": "public .ctor(Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.AuthenticatedEncryptionSettings settings, Microsoft.AspNetCore.DataProtection.ISecret masterKey)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptor : Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.IAuthenticatedEncryptorDescriptor",
+      "MemberId": "public .ctor(Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.AuthenticatedEncryptionSettings settings, Microsoft.AspNetCore.DataProtection.ISecret masterKey, System.IServiceProvider services)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptor : Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.IAuthenticatedEncryptorDescriptor",
+      "MemberId": "public Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.IAuthenticatedEncryptor CreateEncryptorInstance()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.CngCbcAuthenticatedEncryptorDescriptor : Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.IAuthenticatedEncryptorDescriptor",
+      "MemberId": "public .ctor(Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.CngCbcAuthenticatedEncryptionSettings settings, Microsoft.AspNetCore.DataProtection.ISecret masterKey)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.CngCbcAuthenticatedEncryptorDescriptor : Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.IAuthenticatedEncryptorDescriptor",
+      "MemberId": "public .ctor(Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.CngCbcAuthenticatedEncryptionSettings settings, Microsoft.AspNetCore.DataProtection.ISecret masterKey, System.IServiceProvider services)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.CngCbcAuthenticatedEncryptorDescriptor : Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.IAuthenticatedEncryptorDescriptor",
+      "MemberId": "public Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.IAuthenticatedEncryptor CreateEncryptorInstance()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.CngGcmAuthenticatedEncryptorDescriptor : Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.IAuthenticatedEncryptorDescriptor",
+      "MemberId": "public .ctor(Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.CngGcmAuthenticatedEncryptionSettings settings, Microsoft.AspNetCore.DataProtection.ISecret masterKey)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.CngGcmAuthenticatedEncryptorDescriptor : Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.IAuthenticatedEncryptorDescriptor",
+      "MemberId": "public .ctor(Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.CngGcmAuthenticatedEncryptionSettings settings, Microsoft.AspNetCore.DataProtection.ISecret masterKey, System.IServiceProvider services)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.CngGcmAuthenticatedEncryptorDescriptor : Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.IAuthenticatedEncryptorDescriptor",
+      "MemberId": "public Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.IAuthenticatedEncryptor CreateEncryptorInstance()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.ManagedAuthenticatedEncryptorDescriptor : Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.IAuthenticatedEncryptorDescriptor",
+      "MemberId": "public .ctor(Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ManagedAuthenticatedEncryptionSettings settings, Microsoft.AspNetCore.DataProtection.ISecret masterKey)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.ManagedAuthenticatedEncryptorDescriptor : Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.IAuthenticatedEncryptorDescriptor",
+      "MemberId": "public .ctor(Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ManagedAuthenticatedEncryptionSettings settings, Microsoft.AspNetCore.DataProtection.ISecret masterKey, System.IServiceProvider services)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.ManagedAuthenticatedEncryptorDescriptor : Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.IAuthenticatedEncryptorDescriptor",
+      "MemberId": "public Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.IAuthenticatedEncryptor CreateEncryptorInstance()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager : Microsoft.AspNetCore.DataProtection.KeyManagement.IKeyManager, Microsoft.AspNetCore.DataProtection.KeyManagement.Internal.IInternalXmlKeyManager",
+      "MemberId": "public .ctor(Microsoft.AspNetCore.DataProtection.Repositories.IXmlRepository repository, Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.IAuthenticatedEncryptorConfiguration configuration, System.IServiceProvider services)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlEncryptor : Microsoft.AspNetCore.DataProtection.XmlEncryption.IXmlEncryptor",
+      "MemberId": "public .ctor(System.Boolean protectToLocalMachine)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlEncryptor : Microsoft.AspNetCore.DataProtection.XmlEncryption.IXmlEncryptor",
+      "MemberId": "public .ctor(System.Boolean protectToLocalMachine, System.IServiceProvider services)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer : Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.IAuthenticatedEncryptorDescriptorDeserializer",
+      "MemberId": "public .ctor(System.IServiceProvider services)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.CngCbcAuthenticatedEncryptorDescriptorDeserializer : Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.IAuthenticatedEncryptorDescriptorDeserializer",
+      "MemberId": "public .ctor(System.IServiceProvider services)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.CngGcmAuthenticatedEncryptorDescriptorDeserializer : Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.IAuthenticatedEncryptorDescriptorDeserializer",
+      "MemberId": "public .ctor(System.IServiceProvider services)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.ManagedAuthenticatedEncryptorDescriptorDeserializer : Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.IAuthenticatedEncryptorDescriptorDeserializer",
+      "MemberId": "public .ctor(System.IServiceProvider services)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.XmlEncryption.CertificateXmlEncryptor : Microsoft.AspNetCore.DataProtection.XmlEncryption.IInternalCertificateXmlEncryptor, Microsoft.AspNetCore.DataProtection.XmlEncryption.IXmlEncryptor",
+      "MemberId": "public .ctor(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.XmlEncryption.CertificateXmlEncryptor : Microsoft.AspNetCore.DataProtection.XmlEncryption.IInternalCertificateXmlEncryptor, Microsoft.AspNetCore.DataProtection.XmlEncryption.IXmlEncryptor",
+      "MemberId": "public .ctor(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.IServiceProvider services)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.XmlEncryption.CertificateXmlEncryptor : Microsoft.AspNetCore.DataProtection.XmlEncryption.IInternalCertificateXmlEncryptor, Microsoft.AspNetCore.DataProtection.XmlEncryption.IXmlEncryptor",
+      "MemberId": "public .ctor(System.String thumbprint, Microsoft.AspNetCore.DataProtection.XmlEncryption.ICertificateResolver certificateResolver)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.XmlEncryption.CertificateXmlEncryptor : Microsoft.AspNetCore.DataProtection.XmlEncryption.IInternalCertificateXmlEncryptor, Microsoft.AspNetCore.DataProtection.XmlEncryption.IXmlEncryptor",
+      "MemberId": "public .ctor(System.String thumbprint, Microsoft.AspNetCore.DataProtection.XmlEncryption.ICertificateResolver certificateResolver, System.IServiceProvider services)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiNGXmlEncryptor : Microsoft.AspNetCore.DataProtection.XmlEncryption.IXmlEncryptor",
+      "MemberId": "public .ctor(System.String protectionDescriptorRule, Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiNGProtectionDescriptorFlags flags)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiNGXmlEncryptor : Microsoft.AspNetCore.DataProtection.XmlEncryption.IXmlEncryptor",
+      "MemberId": "public .ctor(System.String protectionDescriptorRule, Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiNGProtectionDescriptorFlags flags, System.IServiceProvider services)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public static class Microsoft.AspNetCore.DataProtection.DataProtectionBuilderExtensions",
+      "MemberId": "public static Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder UseCryptographicAlgorithms(this Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder builder, Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.AuthenticatedEncryptionSettings settings)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public static class Microsoft.AspNetCore.DataProtection.DataProtectionBuilderExtensions",
+      "MemberId": "public static Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder UseCustomCryptographicAlgorithms(this Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder builder, Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.CngCbcAuthenticatedEncryptionSettings settings)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public static class Microsoft.AspNetCore.DataProtection.DataProtectionBuilderExtensions",
+      "MemberId": "public static Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder UseCustomCryptographicAlgorithms(this Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder builder, Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.CngGcmAuthenticatedEncryptionSettings settings)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public static class Microsoft.AspNetCore.DataProtection.DataProtectionBuilderExtensions",
+      "MemberId": "public static Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder UseCustomCryptographicAlgorithms(this Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder builder, Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ManagedAuthenticatedEncryptionSettings settings)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.AspNetCore.DataProtection.KeyManagement.IKey",
+      "MemberId": "Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.IAuthenticatedEncryptorDescriptor get_Descriptor()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.AspNetCore.DataProtection.KeyManagement.IKey",
+      "MemberId": "Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.IAuthenticatedEncryptor CreateEncryptor()",
+      "Kind": "Addition"
+    }
+  ]


### PR DESCRIPTION
#212 

@dougbu 

I'll send a separate PR for generating baselines for `DataProtection.Redis` and `DataProtection.AzureStorage` as they need to be checked in to `rel/1.1.2` first.