### PR TITLE
Use IHostingEnvironment to determine application identifier

### DIFF
--- a/src/Microsoft.AspNetCore.DataProtection/DataProtectionServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.DataProtection/DataProtectionServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.AspNetCore.Cryptography.Cng;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.DataProtection.Infrastructure;
 using Microsoft.AspNetCore.DataProtection.Internal;
 using Microsoft.AspNetCore.DataProtection.KeyManagement;
 using Microsoft.AspNetCore.DataProtection.KeyManagement.Internal;
@@ -75,6 +76,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 ServiceDescriptor.Transient<IConfigureOptions<DataProtectionOptions>, DataProtectionOptionsSetup>());
 
             services.TryAddSingleton<IKeyManager, XmlKeyManager>();
+            services.TryAddSingleton<IApplicationDiscriminator, HostingApplicationDiscriminator>();
 
             // Internal services
             services.TryAddSingleton<IDefaultKeyResolver, DefaultKeyResolver>();

--- a/src/Microsoft.AspNetCore.DataProtection/Internal/HostingApplicationDiscriminator.cs
+++ b/src/Microsoft.AspNetCore.DataProtection/Internal/HostingApplicationDiscriminator.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.DataProtection.Infrastructure;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Microsoft.AspNetCore.DataProtection.Internal
+{
+    internal class HostingApplicationDiscriminator : IApplicationDiscriminator
+    {
+        private readonly IHostingEnvironment _hosting;
+
+        // the optional constructor for when IHostingEnvironment is not available from DI
+        public HostingApplicationDiscriminator()
+        {
+        }
+
+        public HostingApplicationDiscriminator(IHostingEnvironment hosting)
+        {
+            _hosting = hosting;
+        }
+
+        public string Discriminator => _hosting?.ContentRootPath;
+    }
+}

--- a/src/Microsoft.AspNetCore.DataProtection/Microsoft.AspNetCore.DataProtection.csproj
+++ b/src/Microsoft.AspNetCore.DataProtection/Microsoft.AspNetCore.DataProtection.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(AspNetCoreVersion)" />


### PR DESCRIPTION
Reverses changes made in #230, which were originally made because hosting was not going to support ns2.0.

Expect a hosting PR too soon.