### PR TITLE
Make RegistryPolicyResolver an interface to fix 3d party DI

### DIFF
--- a/src/Microsoft.AspNetCore.DataProtection/DataProtectionServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.DataProtection/DataProtectionServiceCollectionExtensions.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             if (OSVersionUtil.IsWindows())
             {
-                services.TryAddSingleton<RegistryPolicyResolver>();
+                services.TryAddSingleton<IRegistryPolicyResolver, RegistryPolicyResolver>();
             }
 
             services.TryAddEnumerable(

--- a/src/Microsoft.AspNetCore.DataProtection/IRegistryPolicyResolver.cs
+++ b/src/Microsoft.AspNetCore.DataProtection/IRegistryPolicyResolver.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.DataProtection
+{
+    // Single implementation of this interface is conditionally added to DI on Windows
+    // We have to use interface because some DI implementations would try to activate class
+    // even if it was not registered causing problems crossplat
+    internal interface IRegistryPolicyResolver
+    {
+        RegistryPolicy ResolvePolicy();
+    }
+}

--- a/src/Microsoft.AspNetCore.DataProtection/Internal/KeyManagementOptionsSetup.cs
+++ b/src/Microsoft.AspNetCore.DataProtection/Internal/KeyManagementOptionsSetup.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.DataProtection.Internal
 {
     internal class KeyManagementOptionsSetup : IConfigureOptions<KeyManagementOptions>
     {
-        private readonly RegistryPolicyResolver _registryPolicyResolver;
+        private readonly IRegistryPolicyResolver _registryPolicyResolver;
         private readonly ILoggerFactory _loggerFactory;
 
         public KeyManagementOptionsSetup()
@@ -26,12 +26,12 @@ namespace Microsoft.AspNetCore.DataProtection.Internal
         {
         }
 
-        public KeyManagementOptionsSetup(RegistryPolicyResolver registryPolicyResolver)
+        public KeyManagementOptionsSetup(IRegistryPolicyResolver registryPolicyResolver)
             : this(NullLoggerFactory.Instance, registryPolicyResolver)
         {
         }
 
-        public KeyManagementOptionsSetup(ILoggerFactory loggerFactory, RegistryPolicyResolver registryPolicyResolver)
+        public KeyManagementOptionsSetup(ILoggerFactory loggerFactory, IRegistryPolicyResolver registryPolicyResolver)
         {
             _loggerFactory = loggerFactory;
             _registryPolicyResolver = registryPolicyResolver;

--- a/src/Microsoft.AspNetCore.DataProtection/RegistryPolicyResolver.cs
+++ b/src/Microsoft.AspNetCore.DataProtection/RegistryPolicyResolver.cs
@@ -14,10 +14,15 @@ using Microsoft.Win32;
 
 namespace Microsoft.AspNetCore.DataProtection
 {
+    internal interface IRegistryPolicyResolver
+    {
+        RegistryPolicy ResolvePolicy();
+    }
+
     /// <summary>
     /// A type which allows reading policy from the system registry.
     /// </summary>
-    internal sealed class RegistryPolicyResolver
+    internal sealed class RegistryPolicyResolver: IRegistryPolicyResolver
     {
         private readonly Func<RegistryKey> _getPolicyRegKey;
         private readonly IActivator _activator;
@@ -88,13 +93,7 @@ namespace Microsoft.AspNetCore.DataProtection
             return sinks;
         }
 
-        /// <summary>
-        /// Returns a <see cref="RegistryPolicy"/> from the default registry location.
-        /// </summary>
-        public static RegistryPolicy ResolveDefaultPolicy(IActivator activator)
-            => new RegistryPolicyResolver(activator).ResolvePolicy();
-
-        internal RegistryPolicy ResolvePolicy()
+        public RegistryPolicy ResolvePolicy()
         {
             using (var registryKey = _getPolicyRegKey())
             {

--- a/src/Microsoft.AspNetCore.DataProtection/RegistryPolicyResolver.cs
+++ b/src/Microsoft.AspNetCore.DataProtection/RegistryPolicyResolver.cs
@@ -14,11 +14,6 @@ using Microsoft.Win32;
 
 namespace Microsoft.AspNetCore.DataProtection
 {
-    internal interface IRegistryPolicyResolver
-    {
-        RegistryPolicy ResolvePolicy();
-    }
-
     /// <summary>
     /// A type which allows reading policy from the system registry.
     /// </summary>


### PR DESCRIPTION
Fixes https://github.com/aspnet/DataProtection/issues/274

Some containers would try to activate classes even if they were not registered, switch to interface to prevent it.